### PR TITLE
Use password authentication

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -24,21 +24,11 @@ config :nerves, :erlinit, update_clock: true
 # * See https://hexdocs.pm/nerves_ssh/readme.html for general SSH configuration
 # * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
 
-keys =
-  System.user_home!()
-  |> Path.join(".ssh/id_goatmire.pub")
-  |> Path.wildcard()
-
-if keys == [],
-  do:
-    Mix.raise("""
-    No SSH public keys found in ~/.ssh. An ssh authorized key is needed to
-    log into the Nerves device and update firmware on it using ssh.
-    See your project's config.exs for this error message.
-    """)
-
 config :nerves_ssh,
-  authorized_keys: Enum.map(keys, &File.read!/1)
+  daemon_option_overrides: [
+    {:pwdfun, &NameBadge.ssh_check_pass/2},
+    {:auth_method_kb_interactive_data, &NameBadge.ssh_show_prompt/3}
+    ]
 
 # Configure the network using vintage_net
 #

--- a/lib/name_badge.ex
+++ b/lib/name_badge.ex
@@ -15,4 +15,23 @@ defmodule NameBadge do
   def hello do
     :world
   end
+
+  def ssh_check_pass(_provided_username, provided_password) do
+    correct_password = Application.get_env(:name_badge, :password, "nerves")
+
+    provided_password == to_charlist(correct_password)
+  end
+
+  def ssh_show_prompt(_peer, _username, _service) do
+    {:ok, name} = :inet.gethostname()
+
+    msg = """
+    https://github.com/protolux-electronics/name_badge
+
+    ssh nerves@#{name}.local # Use password "nerves"
+    """
+
+    {~c"Protolux Goatmire Name Badge", to_charlist(msg), ~c"Password: ", false}
+  end
+
 end


### PR DESCRIPTION
This removes public key authorization to make it easier to tell people
how to log into their device. There's no attempt to make this secure as
it's just a starting point.
