### PR TITLE
fix a bug with no partition B flashed

### DIFF
--- a/lib/name_badge/screen/settings/system_info.ex
+++ b/lib/name_badge/screen/settings/system_info.ex
@@ -28,11 +28,11 @@ defmodule NameBadge.Screen.Settings.SystemInfo do
 
     Partition A:
     - Version: #{assigns.version.a}
-    - UUID: #{assigns.version.a_uuid |> String.slice(0..18)}...
+    - UUID: #{if assigns.version.a_uuid, do: String.slice(assigns.version.a_uuid, 0..18) <> "...", else: "N/A"}
 
     Partition B:
-    - Version: #{assigns.version.b} 
-    - UUID: #{assigns.version.b_uuid |> String.slice(0..18)}...
+    - Version: #{assigns.version.b || "N/A"} 
+    - UUID: #{if assigns.version.b_uuid, do: String.slice(assigns.version.b_uuid, 0..18) <> "...", else: "N/A"}
     """
   end
 


### PR DESCRIPTION
When I was trying for first time name badge, I have noticed this bug related to System Info screen which occurs when partition B is not flashed and the result returns nil

<img width="1912" height="400" alt="image" src="https://github.com/user-attachments/assets/2b7b7144-ab0c-4ada-bbbe-6708afcfe084" />
