### PR TITLE
Fix units in Weather screen

### DIFF
--- a/lib/name_badge/screen/weather.ex
+++ b/lib/name_badge/screen/weather.ex
@@ -44,9 +44,9 @@ defmodule NameBadge.Screen.Weather do
   end
 
   def render(%{weather: weather, location: location}) do
-    temp_display = format_temperature(weather.temperature)
+    temp_display = format_temperature(weather.temperature, weather.temperature_unit)
     condition = weather_condition_text(weather.weather_code, weather.is_day)
-    wind_display = format_wind_speed(weather.wind_speed)
+    wind_display = format_wind_speed(weather.wind_speed, weather.wind_speed_unit)
 
     """
     #show heading: set text(font: "Silkscreen", size: 36pt, weight: 400, tracking: -4pt)
@@ -147,17 +147,25 @@ defmodule NameBadge.Screen.Weather do
 
   # Private helper functions
 
-  defp format_temperature(temp) when is_number(temp) do
+  defp format_temperature(temp, unit) when is_number(temp) and is_binary(unit) do
+    "#{round(temp)}#{unit}"
+  end
+
+  defp format_temperature(temp, _unit) when is_number(temp) do
     "#{round(temp)}°C"
   end
 
-  defp format_temperature(_), do: "N/A"
+  defp format_temperature(_, _), do: "N/A"
 
-  defp format_wind_speed(speed) when is_number(speed) do
-    "#{round(speed)} m/s"
+  defp format_wind_speed(speed, unit) when is_number(speed) and is_binary(unit) do
+    "#{round(speed)} #{unit}"
   end
 
-  defp format_wind_speed(_), do: "N/A"
+  defp format_wind_speed(speed, _unit) when is_number(speed) do
+    "#{round(speed)} km/h"
+  end
+
+  defp format_wind_speed(_, _), do: "N/A"
 
   defp format_last_updated(timestamp) when is_binary(timestamp) do
     case DateTime.from_iso8601(timestamp <> ":00Z") do

--- a/lib/name_badge/weather.ex
+++ b/lib/name_badge/weather.ex
@@ -314,13 +314,16 @@ defmodule NameBadge.Weather do
     case Req.get(@openmeteo_url, params: params, receive_timeout: 8_000) do
       {:ok, %{status: 200, body: data}} ->
         current = data["current_weather"]
+        units = data["current_weather_units"] || %{}
 
         weather = %{
           temperature: current["temperature"],
           wind_speed: current["windspeed"],
           weather_code: current["weathercode"],
           is_day: current["is_day"] == 1,
-          timestamp: current["time"]
+          timestamp: current["time"],
+          temperature_unit: units["temperature"] || "°C",
+          wind_speed_unit: units["windspeed"] || "km/h"
         }
 
         {:ok, weather}


### PR DESCRIPTION
Fixes the units by taking them from the response

example request calls Berlin city lat and long

```bash
curl "https://api.open-meteo.com/v1/forecast?latitude=52.52&longitude=13.41&current_weather=true&timezone=auto"
```

```json
{
  "latitude": 52.52,
  "longitude": 13.419998,
  "generationtime_ms": 0.08189678192138672,
  "utc_offset_seconds": 3600,
  "timezone": "Europe/Berlin",
  "timezone_abbreviation": "GMT+1",
  "elevation": 38,
  "current_weather_units": {
    "time": "iso8601",
    "interval": "seconds",
    "temperature": "°C",
    "windspeed": "km/h",
    "winddirection": "°",
    "is_day": "",
    "weathercode": "wmo code"
  },
  "current_weather": {
    "time": "2026-02-19T16:15",
    "interval": 900,
    "temperature": -0.1,
    "windspeed": 12.1,
    "winddirection": 73,
    "is_day": 1,
    "weathercode": 3
  }
}
```

<img width="1690" height="1083" alt="image" src="https://github.com/user-attachments/assets/63ccc21b-3f60-43fc-a70f-0283d0b851cf" />
